### PR TITLE
Add support for overrides + parser refactoring

### DIFF
--- a/controllers/lineAnnotationsController.js
+++ b/controllers/lineAnnotationsController.js
@@ -54,7 +54,7 @@ function addAnnotations(editor) {
                 const contentText = getContentText(rule, ruleInfo);
                 const hoverMessage = getHoverMessage(rule, ruleInfo);
                 let decoration = getDecorationObject(contentText, hoverMessage);
-                decoration.range = rule.lineEndingRange;
+                decoration.range = rule.eolRange;
                 return decoration;
             });
     }))

--- a/parsers/AcornParser.js
+++ b/parsers/AcornParser.js
@@ -1,0 +1,36 @@
+const vscode = require('vscode');
+const acorn = require('acorn');
+const Parser = require('./Parser');
+
+module.exports = class AcornParser extends Parser {
+    constructor(document) {
+        if (new.target === AcornParser) {
+            throw new Error('AcornParser cannot be instantiated directly.');
+        }
+
+        super(document);
+    }
+
+    get ast() {
+        // This default implementation fits for JSON and Package parsers.
+        // JS parser overrides it.
+        return acorn.parseExpressionAt(this.document.getText(), 0, { locations: true });
+    }
+
+    getProps(node) {
+        return node.properties;
+    }
+
+    getItems(node) {
+        return node.elements;
+    }
+
+    getRuleLocation(rule) {
+        const [start, end] = [rule.key.loc.start, rule.key.loc.end];
+
+        return [
+            new vscode.Position(start.line - 1, start.column),
+            new vscode.Position(end.line - 1, end.column),
+        ];
+    }
+};

--- a/parsers/DocumentParser.js
+++ b/parsers/DocumentParser.js
@@ -19,11 +19,15 @@ module.exports = class DocumentParser extends Parser {
                 return new JSParser(document);
             } else if (isMatch('**/.eslintrc.json', 'json')) {
                 return new JSONParser(document);
+            } else if (isMatch('**/.eslintrc.json', 'jsonc')) {
+                return new JSONParser(document);
             } else if (isMatch('**/.eslintrc.yaml', 'yaml')) {
                 return new YAMLParser(document);
             } else if (isMatch('**/.eslintrc.yml', 'yaml')) {
                 return new YAMLParser(document);
             } else if (isMatch('**/.eslintrc', 'json')) {
+                return new JSONParser(document);
+            } else if (isMatch('**/.eslintrc', 'jsonc')) {
                 return new JSONParser(document);
             } else if (isMatch('**/.eslintrc', 'yaml')) {
                 return new YAMLParser(document);

--- a/parsers/DocumentParser.js
+++ b/parsers/DocumentParser.js
@@ -10,20 +10,24 @@ module.exports = class DocumentParser extends Parser {
     constructor(document) {
         super(document);
 
+        function isMatch(pattern, language) {
+            return vscode.languages.match({ pattern, scheme: 'file', language }, document) > 0;
+        }
+
         if (new.target === DocumentParser) {
-            if (vscode.languages.match({ pattern: '**/.eslintrc.js', scheme: 'file', language: 'javascript' }, document) > 0) {
+            if (isMatch('**/.eslintrc.js', 'javascript')) {
                 return new JSParser(document);
-            } else if (vscode.languages.match({ pattern: '**/.eslintrc.json', scheme: 'file', language: 'json' }, document) > 0) {
+            } else if (isMatch('**/.eslintrc.json', 'json')) {
                 return new JSONParser(document);
-            } else if (vscode.languages.match({ pattern: '**/.eslintrc.yaml', scheme: 'file', language: 'yaml' }, document) > 0) {
+            } else if (isMatch('**/.eslintrc.yaml', 'yaml')) {
                 return new YAMLParser(document);
-            } else if (vscode.languages.match({ pattern: '**/.eslintrc.yml', scheme: 'file', language: 'yaml' }, document) > 0) {
+            } else if (isMatch('**/.eslintrc.yml', 'yaml')) {
                 return new YAMLParser(document);
-            } else if (vscode.languages.match({ pattern: '**/.eslintrc', scheme: 'file', language: 'json' }, document) > 0) {
+            } else if (isMatch('**/.eslintrc', 'json')) {
                 return new JSONParser(document);
-            } else if (vscode.languages.match({ pattern: '**/.eslintrc', scheme: 'file', language: 'yaml' }, document) > 0) {
+            } else if (isMatch('**/.eslintrc', 'yaml')) {
                 return new YAMLParser(document);
-            } else if (vscode.languages.match({ pattern: '**/package.json', scheme: 'file', language: 'json' }, document) > 0) {
+            } else if (isMatch('**/package.json', 'json')) {
                 return new PkgParser(document);
             }
     

--- a/parsers/JSONParser.js
+++ b/parsers/JSONParser.js
@@ -1,55 +1,7 @@
-const vscode = require('vscode');
-const acorn = require('acorn');
-const Parser = require('./Parser');
+const AcornParser = require('./AcornParser');
 
-module.exports = class JSONParser extends Parser {
+module.exports = class JSONParser extends AcornParser {
     constructor(document) {
         super(document);
-    }
-
-    parse() {
-        const ast = acorn.parseExpressionAt(this.document.getText(), 0, { locations: true });
-
-        const mainRules = this.getRulesFromNode(ast);
-
-        const overrideRules = ast.properties
-            .filter(prop => prop.key.value === 'overrides')
-            .flatMap(prop => prop.value.elements.flatMap(item => this.getRulesFromNode(item)));
-
-        return mainRules.concat(overrideRules);
-    }
-
-    getRulesFromNode(node) {
-        return node.properties
-            .filter(prop => prop.key.value === 'rules')
-            .flatMap(prop => prop.value.properties.map(rule => this.getRule(rule)));
-    }
-
-    getRule(rule) {
-        let keyStartPosition = new vscode.Position(
-            rule.key.loc.start.line - 1,
-            rule.key.loc.start.column,
-        );
-        let keyEndPosition = new vscode.Position(
-            rule.key.loc.end.line - 1,
-            rule.key.loc.end.column,
-        );
-        let keyRange = this.document.validateRange(
-            new vscode.Range(keyStartPosition, keyEndPosition),
-        );
-        let lineEndingRange = this.document.validateRange(
-            new vscode.Range(
-                rule.key.loc.start.line - 1,
-                Number.MAX_SAFE_INTEGER,
-                rule.key.loc.start.line - 1,
-                Number.MAX_SAFE_INTEGER,
-            ),
-        );
-
-        return {
-            name: rule.key.value,
-            keyRange,
-            lineEndingRange,
-        };
     }
 };

--- a/parsers/JSONParser.js
+++ b/parsers/JSONParser.js
@@ -8,26 +8,48 @@ module.exports = class JSONParser extends Parser {
     }
 
     parse() {
-        let rules = [];
-        let ast = acorn.parseExpressionAt(this.document.getText(), 0, { locations: true });
+        const ast = acorn.parseExpressionAt(this.document.getText(), 0, { locations: true });
 
-        ast.properties.forEach(prop => {
-            if (prop.key.value === 'rules') {
-                prop.value.properties.forEach(rule => {
-                    let keyStartPosition = new vscode.Position(rule.key.loc.start.line - 1, rule.key.loc.start.column);
-                    let keyEndPosition = new vscode.Position(rule.key.loc.end.line - 1, rule.key.loc.end.column);
-                    let keyRange = this.document.validateRange(new vscode.Range(keyStartPosition, keyEndPosition));
-                    let lineEndingRange = this.document.validateRange(new vscode.Range(rule.key.loc.start.line - 1, Number.MAX_SAFE_INTEGER, rule.key.loc.start.line - 1, Number.MAX_SAFE_INTEGER));
+        const mainRules = this.getRulesFromNode(ast);
 
-                    rules.push({
-                        name: rule.key.value,
-                        keyRange,
-                        lineEndingRange
-                    });
-                });
-            }
-        });
+        const overrideRules = ast.properties
+            .filter(prop => prop.key.value === 'overrides')
+            .flatMap(prop => prop.value.elements.flatMap(item => this.getRulesFromNode(item)));
 
-        return rules;
+        return mainRules.concat(overrideRules);
+    }
+
+    getRulesFromNode(node) {
+        return node.properties
+            .filter(prop => prop.key.value === 'rules')
+            .flatMap(prop => prop.value.properties.map(rule => this.getRule(rule)));
+    }
+
+    getRule(rule) {
+        let keyStartPosition = new vscode.Position(
+            rule.key.loc.start.line - 1,
+            rule.key.loc.start.column,
+        );
+        let keyEndPosition = new vscode.Position(
+            rule.key.loc.end.line - 1,
+            rule.key.loc.end.column,
+        );
+        let keyRange = this.document.validateRange(
+            new vscode.Range(keyStartPosition, keyEndPosition),
+        );
+        let lineEndingRange = this.document.validateRange(
+            new vscode.Range(
+                rule.key.loc.start.line - 1,
+                Number.MAX_SAFE_INTEGER,
+                rule.key.loc.start.line - 1,
+                Number.MAX_SAFE_INTEGER,
+            ),
+        );
+
+        return {
+            name: rule.key.value,
+            keyRange,
+            lineEndingRange,
+        };
     }
 };

--- a/parsers/JSParser.js
+++ b/parsers/JSParser.js
@@ -2,49 +2,81 @@ const vscode = require('vscode');
 const acorn = require('acorn');
 const Parser = require('./Parser');
 
+function getPropValue(prop) {
+    switch (prop.key.type) {
+        case 'Literal':
+            return prop.key.value;
+        case 'Identifier':
+            return prop.key.name;
+    }
+}
+
 module.exports = class JSParser extends Parser {
     constructor(document) {
         super(document);
     }
 
     parse() {
-        let rules = [];
         let ast = acorn.parse(this.document.getText(), { locations: true, sourceType: 'module' });
 
-        ast.body.forEach(stmt => {
-            if (stmt.type === 'ExpressionStatement' && stmt.expression.type === 'AssignmentExpression') {
-                if (stmt.expression.left.type === 'MemberExpression') {
-                    if (stmt.expression.left.object.name === 'module' && stmt.expression.left.property.name === 'exports') {
-                        stmt.expression.right.properties.forEach(prop => {
-                            if ((prop.key.type === 'Literal' && prop.key.value === 'rules') || (prop.key.type === 'Identifier' && prop.key.name === 'rules')) {
-                                prop.value.properties.forEach(rule => {
-                                    let keyStartPosition = new vscode.Position(rule.key.loc.start.line - 1, rule.key.loc.start.column);
-                                    let keyEndPosition = new vscode.Position(rule.key.loc.end.line - 1, rule.key.loc.end.column);
-                                    let keyRange = this.document.validateRange(new vscode.Range(keyStartPosition, keyEndPosition));
-                                    let lineEndingRange = this.document.validateRange(new vscode.Range(rule.key.loc.start.line - 1, Number.MAX_SAFE_INTEGER, rule.key.loc.start.line - 1, Number.MAX_SAFE_INTEGER));
+        return ast.body
+            .filter(
+                stmt =>
+                    stmt.type === 'ExpressionStatement' &&
+                    stmt.expression.type === 'AssignmentExpression' &&
+                    stmt.expression.left.type === 'MemberExpression' &&
+                    stmt.expression.left.object.name === 'module' &&
+                    stmt.expression.left.property.name === 'exports',
+            )
+            .flatMap(stmt => {
+                const mainRules = this.getRulesFromNode(stmt.expression.right);
 
-                                    let name;
-                                    if (rule.key.type === 'Literal') {
-                                        name = rule.key.value;
-                                    } else if (rule.key.type === 'Identifier') {
-                                        name = rule.key.name;
-                                    } else {
-                                        return;
-                                    }
+                const overrideRules = stmt.expression.right.properties
+                    .filter(prop => getPropValue(prop) === 'overrides')
+                    .flatMap(prop =>
+                        prop.value.elements.flatMap(item => this.getRulesFromNode(item)),
+                    );
 
-                                    rules.push({
-                                        name,
-                                        keyRange,
-                                        lineEndingRange
-                                    });
-                                });
-                            }
-                        });
-                    }
-                }
-            }
-        });
+                return mainRules.concat(overrideRules);
+            });
+    }
 
-        return rules;
+    getRulesFromNode(node) {
+        return node.properties
+            .filter(prop => getPropValue(prop) === 'rules')
+            .flatMap(prop => prop.value.properties.map(rule => this.getRule(rule)));
+    }
+
+    getRule(rule) {
+        let keyStartPosition = new vscode.Position(
+            rule.key.loc.start.line - 1,
+            rule.key.loc.start.column,
+        );
+        let keyEndPosition = new vscode.Position(
+            rule.key.loc.end.line - 1,
+            rule.key.loc.end.column,
+        );
+        let keyRange = this.document.validateRange(
+            new vscode.Range(keyStartPosition, keyEndPosition),
+        );
+        let lineEndingRange = this.document.validateRange(
+            new vscode.Range(
+                rule.key.loc.start.line - 1,
+                Number.MAX_SAFE_INTEGER,
+                rule.key.loc.start.line - 1,
+                Number.MAX_SAFE_INTEGER,
+            ),
+        );
+
+        let name = getPropValue(rule);
+        if (!name) {
+            return;
+        }
+
+        return {
+            name,
+            keyRange,
+            lineEndingRange,
+        };
     }
 };

--- a/parsers/JSParser.js
+++ b/parsers/JSParser.js
@@ -1,82 +1,36 @@
-const vscode = require('vscode');
 const acorn = require('acorn');
-const Parser = require('./Parser');
+const AcornParser = require('./AcornParser');
 
-function getPropValue(prop) {
-    switch (prop.key.type) {
-        case 'Literal':
-            return prop.key.value;
-        case 'Identifier':
-            return prop.key.name;
-    }
-}
-
-module.exports = class JSParser extends Parser {
+module.exports = class JSParser extends AcornParser {
     constructor(document) {
         super(document);
     }
 
-    parse() {
-        let ast = acorn.parse(this.document.getText(), { locations: true, sourceType: 'module' });
-
-        return ast.body
-            .filter(
-                stmt =>
-                    stmt.type === 'ExpressionStatement' &&
-                    stmt.expression.type === 'AssignmentExpression' &&
-                    stmt.expression.left.type === 'MemberExpression' &&
-                    stmt.expression.left.object.name === 'module' &&
-                    stmt.expression.left.property.name === 'exports',
-            )
-            .flatMap(stmt => {
-                const mainRules = this.getRulesFromNode(stmt.expression.right);
-
-                const overrideRules = stmt.expression.right.properties
-                    .filter(prop => getPropValue(prop) === 'overrides')
-                    .flatMap(prop =>
-                        prop.value.elements.flatMap(item => this.getRulesFromNode(item)),
-                    );
-
-                return mainRules.concat(overrideRules);
-            });
+    get ast() {
+        return acorn.parse(this.document.getText(), { locations: true, sourceType: 'module' });
     }
 
-    getRulesFromNode(node) {
-        return node.properties
-            .filter(prop => getPropValue(prop) === 'rules')
-            .flatMap(prop => prop.value.properties.map(rule => this.getRule(rule)));
+    get rules() {
+        return this.ast.body
+            .filter(isModuleExports)
+            .flatMap(statement => this.getAllRules(statement.expression.right));
     }
 
-    getRule(rule) {
-        let keyStartPosition = new vscode.Position(
-            rule.key.loc.start.line - 1,
-            rule.key.loc.start.column,
-        );
-        let keyEndPosition = new vscode.Position(
-            rule.key.loc.end.line - 1,
-            rule.key.loc.end.column,
-        );
-        let keyRange = this.document.validateRange(
-            new vscode.Range(keyStartPosition, keyEndPosition),
-        );
-        let lineEndingRange = this.document.validateRange(
-            new vscode.Range(
-                rule.key.loc.start.line - 1,
-                Number.MAX_SAFE_INTEGER,
-                rule.key.loc.start.line - 1,
-                Number.MAX_SAFE_INTEGER,
-            ),
-        );
-
-        let name = getPropValue(rule);
-        if (!name) {
-            return;
-        }
-
-        return {
-            name,
-            keyRange,
-            lineEndingRange,
-        };
+    getNodeKey(node) {
+        return node.key.type === 'Identifier'
+            ? node.key.name
+            : node.key.type === 'Literal'
+            ? node.key.value
+            : undefined;
     }
 };
+
+function isModuleExports(statement) {
+    return (
+        statement.type === 'ExpressionStatement' &&
+        statement.expression.type === 'AssignmentExpression' &&
+        statement.expression.left.type === 'MemberExpression' &&
+        statement.expression.left.object.name === 'module' &&
+        statement.expression.left.property.name === 'exports'
+    );
+}

--- a/parsers/Parser.js
+++ b/parsers/Parser.js
@@ -1,3 +1,5 @@
+const vscode = require('vscode');
+
 module.exports = class Parser {
     constructor(document) {
         if (new.target === Parser) {
@@ -7,31 +9,97 @@ module.exports = class Parser {
         this.document = document;
     }
 
-    parse() {
-        return [];
+    getRules() {
+        const rules = this.rules;
+
+        return rules && rules.length ? this.flagDuplicates(rules) : [];
     }
 
-    getRules() {
-        let rules = this.parse();
+    get rules() {
+        // This default implementation fits for for YAML and JSON parsers.
+        // JS & Package parsers override it.
+        return this.getAllRules(this.ast);
+    }
 
-        if (!rules || rules.length === 0) {
-            return rules;
-        }
+    get ast() {
+        throw new Error('ast getter must be implemented in the child class.');
+    }
 
-        return this.flagDuplicates(rules);
+    getNodeKey(node) {
+        // This default implementation fits for YAML, JSON, and Package parsers.
+        // JS parser overrides it.
+        return node.key.value;
+    }
+
+    /** Gets properties of an object-like AST node. */
+    getProps(node) {
+        throw new Error('getProps method must be implemented in the child class.');
+    }
+
+    /** Gets elements of an array-like AST node. */
+    getItems(node) {
+        throw new Error('getItems method must be implemented in the child class.');
+    }
+
+    /** Flatmaps `callback` over `node`'s child property (or children properties) named `key`. */
+    mapChildren(node, key, callback) {
+        return this.getProps(node)
+            .filter(prop => this.getNodeKey(prop) === key)
+            .flatMap(prop => callback(prop.value));
+    }
+
+    /** Gets both plain and overridden rules from `node`. */
+    getAllRules(node) {
+        const mainRules = this.getRulesFromNode(node);
+        const overrideRules = this.getOverridesFromNode(node);
+
+        return mainRules.concat(overrideRules);
+    }
+
+    /** Gets rules from AST node, assuming this node has 'rules' child. */
+    getRulesFromNode(node) {
+        return this.mapChildren(node, 'rules', value =>
+            this.getProps(value).map(rule => this.getRule(rule)),
+        );
+    }
+
+    /** Gets rules from AST node, assuming this node has 'overrides' child. */
+    getOverridesFromNode(node) {
+        return this.mapChildren(node, 'overrides', value =>
+            this.getItems(value).flatMap(item => this.getRulesFromNode(item)),
+        );
+    }
+
+    /** Gets start and end positions of the rule location in the document. */
+    getRuleLocation(rule) {
+        throw new Error('getRuleLocation method must be implemented in the child class.');
+    }
+
+    getRule(rule) {
+        const [start, end] = this.getRuleLocation(rule);
+
+        const name = this.getNodeKey(rule);
+        const keyRange = this.document.validateRange(new vscode.Range(start, end));
+        const eol = new vscode.Position(keyRange.start.line, Number.MAX_SAFE_INTEGER);
+        const eolRange = this.document.validateRange(new vscode.Range(eol, eol));
+
+        return { name, keyRange, eolRange };
     }
 
     flagDuplicates(rules) {
-        let ruleNames = rules.map(rule => rule.name);
+        const ruleNames = rules.map(rule => rule.name);
 
-        return rules.map((rule, index) => {
-            let otherIndex = ruleNames.indexOf(rule.name, index + 1);
-            if (otherIndex > -1) {
-                rule.duplicate = true;
+        rules.forEach((rule, index) => {
+            if (rule.duplicate) {
+                return;
+            }
+            const otherIndex = ruleNames.indexOf(rule.name, index + 1);
+            if (~otherIndex) {
+                rules[index].duplicate = true;
                 rules[otherIndex].duplicate = true;
             }
-
-            return rule;
         });
+
+        return rules;
     }
-}
+};

--- a/parsers/PkgParser.js
+++ b/parsers/PkgParser.js
@@ -1,61 +1,11 @@
-const vscode = require('vscode');
-const acorn = require('acorn');
-const Parser = require('./Parser');
+const AcornParser = require('./AcornParser');
 
-module.exports = class PkgParser extends Parser {
+module.exports = class PkgParser extends AcornParser {
     constructor(document) {
         super(document);
     }
 
-    parse() {
-        let ast = acorn.parseExpressionAt(this.document.getText(), 0, { locations: true });
-
-        return ast.properties
-            .filter(prop => prop.key.value === 'eslintConfig')
-            .flatMap(prop => {
-                const mainRules = this.getRulesFromNode(prop.value);
-
-                const overrideRules = prop.value.properties
-                    .filter(prop => prop.key.value === 'overrides')
-                    .flatMap(prop =>
-                        prop.value.elements.flatMap(item => this.getRulesFromNode(item)),
-                    );
-
-                return mainRules.concat(overrideRules);
-            });
-    }
-
-    getRulesFromNode(node) {
-        return node.properties
-            .filter(prop => prop.key.value === 'rules')
-            .flatMap(prop => prop.value.properties.map(rule => this.getRule(rule)));
-    }
-
-    getRule(rule) {
-        let keyStartPosition = new vscode.Position(
-            rule.key.loc.start.line - 1,
-            rule.key.loc.start.column,
-        );
-        let keyEndPosition = new vscode.Position(
-            rule.key.loc.end.line - 1,
-            rule.key.loc.end.column,
-        );
-        let keyRange = this.document.validateRange(
-            new vscode.Range(keyStartPosition, keyEndPosition),
-        );
-        let lineEndingRange = this.document.validateRange(
-            new vscode.Range(
-                rule.key.loc.start.line - 1,
-                Number.MAX_SAFE_INTEGER,
-                rule.key.loc.start.line - 1,
-                Number.MAX_SAFE_INTEGER,
-            ),
-        );
-
-        return {
-            name: rule.key.value,
-            keyRange,
-            lineEndingRange,
-        };
+    get rules() {
+        return this.mapChildren(this.ast, 'eslintConfig', value => this.getAllRules(value));
     }
 };

--- a/parsers/YAMLParser.js
+++ b/parsers/YAMLParser.js
@@ -8,26 +8,42 @@ module.exports = class YAMLParser extends Parser {
     }
 
     parse() {
-        let rules = [];
-        let ast = yaml.load(this.document.getText());
+        const ast = yaml.load(this.document.getText());
 
-        ast.mappings.forEach(prop => {
-            if (prop.key.value === 'rules') {
-                prop.value.mappings.forEach(rule => {
-                    let keyStartPosition = this.document.positionAt(rule.startPosition - 1);
-                    let keyEndPosition = this.document.positionAt(rule.endPosition - 1);
-                    let keyRange = this.document.validateRange(new vscode.Range(keyStartPosition, keyEndPosition));
-                    let lineEndingRange = this.document.validateRange(new vscode.Range(keyStartPosition.line, Number.MAX_SAFE_INTEGER, keyStartPosition.line, Number.MAX_SAFE_INTEGER));
-    
-                    rules.push({
-                        name: rule.key.value,
-                        keyRange,
-                        lineEndingRange
-                    });
-                });
-            }
-        });
-    
-        return rules;
+        const mainRules = this.getRulesFromNode(ast);
+
+        const overrideRules = ast.mappings
+            .filter(prop => prop.key.value === 'overrides')
+            .flatMap(prop => prop.value.items.flatMap(item => this.getRulesFromNode(item)));
+
+        return mainRules.concat(overrideRules);
+    }
+
+    getRulesFromNode(node) {
+        return node.mappings
+            .filter(prop => prop.key.value === 'rules')
+            .flatMap(prop => prop.value.mappings.map(rule => this.getRule(rule)));
+    }
+
+    getRule(rule) {
+        let keyStartPosition = this.document.positionAt(rule.startPosition - 1);
+        let keyEndPosition = this.document.positionAt(rule.endPosition - 1);
+        let keyRange = this.document.validateRange(
+            new vscode.Range(keyStartPosition, keyEndPosition),
+        );
+        let lineEndingRange = this.document.validateRange(
+            new vscode.Range(
+                keyStartPosition.line,
+                Number.MAX_SAFE_INTEGER,
+                keyStartPosition.line,
+                Number.MAX_SAFE_INTEGER,
+            ),
+        );
+
+        return {
+            name: rule.key.value,
+            keyRange,
+            lineEndingRange,
+        };
     }
 };


### PR DESCRIPTION
Support for overrides + some refactoring of parsers. #13

Known ~bug~ feature: if a rule appears in both main rules section and overrides rules section, or in two or more overrides rules sections, the declarations of this rule are marked as duplicate. I'm not sure if it's actually an error: in fact, since it's defined twice, we can say it's duplicate. Of course it's better to mark such rules as overridden rule or something, but this requires more changes (a separate rule list for every rules section, "overridden rule" glyph, etc.).

And also added JSON with Comments (jsonc) support. #11 