### PR TITLE
Fix for plugin names with scopes

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -173,10 +173,6 @@ function getPluginPackageName(pluginName) {
     }
 
     if (pluginName.startsWith('@')) {
-        if (pluginName.includes('/')) {
-            const [scope, plugin] = pluginName.split('/');
-            return `${scope}/${eslintPluginPrefix}-${plugin}`;
-        }
         return `${pluginName}/${eslintPluginPrefix}`;
     }
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -76,9 +76,9 @@ function breakOutRuleName(ruleName) {
     if (scope || plugin) {
         if (scope && plugin) {
             pluginName = `${scope}/${plugin}`;
+        } else {
+            pluginName = scope || plugin;
         }
-
-        pluginName = scope || plugin;
     }
 
     return {
@@ -163,6 +163,7 @@ export function getRuleDetails(ruleName) {
 }
 
 function getPluginPackageName(pluginName) {
+    console.log('*****', pluginName)
     if (!pluginName) {
         return '';
     }
@@ -173,6 +174,10 @@ function getPluginPackageName(pluginName) {
     }
 
     if (pluginName.startsWith('@')) {
+        if (pluginName.includes('/')) {
+            const [scope, plugin] = pluginName.split('/');
+            return `${scope}/${eslintPluginPrefix}-${plugin}`;
+        }
         return `${pluginName}/${eslintPluginPrefix}`;
     }
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -163,7 +163,6 @@ export function getRuleDetails(ruleName) {
 }
 
 function getPluginPackageName(pluginName) {
-    console.log('*****', pluginName)
     if (!pluginName) {
         return '';
     }


### PR DESCRIPTION
- According to the [ESLint plugin naming conventions](https://eslint.org/docs/user-guide/configuring/plugins#naming-convention), `plugins` of the form `@foo/eslint-plugin-foo` can exist, which currently are not supported by Lint Lens as the plugin name gets cut off.
- For example, the following plugin name is missing `-cds`:
![Screenshot 2022-01-12 at 18 43 36](https://user-images.githubusercontent.com/8320933/149193971-77b31588-9717-47cd-99d5-db32edcb9577.png)
- Related issue: https://github.com/ghmcadams/vscode-lintlens/issues/42
- Fixing the plugin name resolution, all rule descriptions can now be displayed properly:
![Screenshot 2022-01-12 at 18 45 17](https://user-images.githubusercontent.com/8320933/149194137-a2419127-7213-42ed-a525-2a9e5c3f4549.png)

