### PR TITLE
Fix update detection of eslint for yarn pnp mode

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -2,7 +2,9 @@ import { getWorkspaceDir } from './workspace';
 import { MissingESLintError, UnsupportedESLintError } from './errors';
 
 
-const eslintPackagePath = getWorkspaceDir('./node_modules/eslint');
+const eslintPackagePath =
+    getWorkspaceDir('./node_modules/eslint') ||
+    getWorkspaceDir('.yarn/sdks/eslint');
 
 if (!eslintPackagePath) {
     throw new MissingESLintError();


### PR DESCRIPTION
Fix detection of eslint for yarn pnp enabled workspaces.
Assumes [yarn vscode sdk](https://yarnpkg.com/getting-started/editor-sdks) has been installed.

Resolves: #49